### PR TITLE
added ignore list and also tracking where a new program gets opened

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 nest is an automatic window switcher for [Hyprland](https://github.com/hyprwm/Hyprland).  
 It learns where you like your apps to live and ensures they always end up in the right workspace, no hunting, no moving, no friction.
-
+Kind of like [zoxide](https://github.com/ajeetdsouza/zoxide), but for window switching.
 ## Features
 
 - **Learns your habits** – remembers where you usually place apps.
@@ -47,5 +47,6 @@ Example `config.toml`:
 tau = 3600.0  # Decay constant for learning: e^(-age/tau), where age is in seconds (default = 1h)  
 buffer = 30  # Number of records to keep per program class  
 save_frequency = 10  # Seconds between saves (no save if no changes)  
-log_level = "INFO"  # OFF, ERROR, WARN, INFO, DEBUG, TRACE`
+log_level = "INFO"  # OFF, ERROR, WARN, INFO, DEBUG, TRACE
+ignore = []  # List of program classes to ignore (see storage.txt for the classes that are being tracked)
 ```

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,7 @@ pub struct Config {
     pub buffer: usize,
     pub save_frequency: u64,
     pub log_level: String,
+    pub ignore: Vec<String>,
 }
 
 impl Config {
@@ -59,6 +60,7 @@ impl Default for Config {
             tau: 3600.0,
             buffer: 30,
             save_frequency: 10,
+            ignore: Vec::new(),
             log_level: log::LevelFilter::Info.as_str().to_string(),
         }
     }


### PR DESCRIPTION
Previously, nest only tracked programs when they were moved. This meant that when a user opened a new program, it wouldn’t be tracked until the first move.

This PR adds tracking of the workspace when a program is first opened. Now, when a new program appears, nest populates its state with the workspace where it was initially opened.

Introducing this feature uncovered a new issue: some programs, like application launchers, are meant to be global but were being tracked and locked to a single workspace. To address this, an ignore list has been added so certain programs are excluded from tracking.