### PR TITLE
Moves state.rs into a state module

### DIFF
--- a/src/state/floatingwindow.rs
+++ b/src/state/floatingwindow.rs
@@ -1,0 +1,43 @@
+use std::{fmt::Display, str::FromStr};
+
+use crate::state::ParseError;
+
+#[derive(Clone, Debug)]
+pub struct FloatingWindow {
+    pub at: (i16, i16),
+    pub size: (i16, i16),
+}
+
+impl Display for FloatingWindow {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{};{};{};{}",
+            self.at.0, self.at.1, self.size.0, self.size.1
+        )
+    }
+}
+
+impl FromStr for FloatingWindow {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err(ParseError::InvalidFormat);
+        }
+        let parts: Vec<&str> = s.split(";").collect();
+        if parts.len() != 4 {
+            return Err(ParseError::InvalidFormat);
+        }
+
+        let at_x: i16 = parts[0].parse()?;
+        let at_y: i16 = parts[1].parse()?;
+        let size_x: i16 = parts[2].parse()?;
+        let size_y: i16 = parts[3].parse()?;
+
+        Ok(FloatingWindow {
+            at: (at_x, at_y),
+            size: (size_x, size_y),
+        })
+    }
+}

--- a/src/state/program.rs
+++ b/src/state/program.rs
@@ -1,0 +1,64 @@
+use std::{fmt::Display, str::FromStr};
+
+use crate::state::{FloatingWindow, ParseError, Workspace};
+
+#[derive(Clone, Debug)]
+pub struct Program {
+    pub class: String,
+    pub workspaces: Vec<Workspace>,
+    pub floating_window: Option<FloatingWindow>,
+    pub moved: bool,
+    pub float_moved: bool,
+}
+
+impl Display for Program {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:[", self.class)?;
+        for (i, workspace) in self.workspaces.iter().enumerate() {
+            write!(f, "{}", workspace)?;
+            if i != self.workspaces.len() - 1 {
+                write!(f, ",")?;
+            }
+        }
+        match &self.floating_window {
+            Some(floating_window) => write!(f, "]&[{}]", floating_window),
+            None => write!(f, "]&[]"),
+        }
+    }
+}
+
+impl FromStr for Program {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let split: Vec<&str> = s.split(':').collect();
+        let class = split.first().unwrap_or(&"0");
+        let data: Vec<&str> = split.last().unwrap_or(&"0").split('&').collect();
+
+        let workspaces_str: Vec<&str> = data
+            .first()
+            .unwrap_or(&"0")
+            .trim()
+            .trim_matches(['[', ']'])
+            .split(',')
+            .collect();
+
+        let mut workspaces: Vec<Workspace> = Vec::with_capacity(workspaces_str.len());
+        for workspace_str in workspaces_str.iter() {
+            let workspace = Workspace::from_str(workspace_str)?;
+            workspaces.push(workspace);
+        }
+
+        let window_str = data.last().unwrap_or(&"0").trim().trim_matches(['[', ']']);
+
+        let floating_window = FloatingWindow::from_str(window_str).ok();
+
+        Ok(Program {
+            class: class.to_string(),
+            workspaces,
+            floating_window,
+            moved: false,
+            float_moved: false,
+        })
+    }
+}

--- a/src/state/safemap.rs
+++ b/src/state/safemap.rs
@@ -1,0 +1,16 @@
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::Mutex;
+
+pub struct SafeMap<T, U>(pub Arc<Mutex<HashMap<T, U>>>);
+
+impl<T, U> SafeMap<T, U> {
+    pub fn new() -> Self {
+        SafeMap(Arc::new(Mutex::new(HashMap::new())))
+    }
+}
+
+impl<T, U> Clone for SafeMap<T, U> {
+    fn clone(&self) -> Self {
+        SafeMap(self.0.clone())
+    }
+}

--- a/src/state/window.rs
+++ b/src/state/window.rs
@@ -1,0 +1,8 @@
+use chrono::{DateTime, Utc};
+
+#[derive(Clone, Debug)]
+pub struct Window {
+    pub class: String,
+    pub timestamp: DateTime<Utc>,
+    pub origin: i32,
+}

--- a/src/state/workspace.rs
+++ b/src/state/workspace.rs
@@ -1,0 +1,37 @@
+use std::{fmt::Display, str::FromStr};
+
+use crate::state::ParseError;
+
+#[derive(Clone, Debug)]
+pub struct Workspace {
+    pub workspace_id: i32,
+    pub timestamp: i64,
+}
+
+impl Display for Workspace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{};{}", self.workspace_id, self.timestamp)
+    }
+}
+
+impl FromStr for Workspace {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err(ParseError::InvalidFormat);
+        }
+        let parts: Vec<&str> = s.split(";").collect();
+        if parts.len() != 2 {
+            return Err(ParseError::InvalidFormat);
+        }
+
+        let workspace_id: i32 = parts[0].parse()?;
+        let timestamp: i64 = parts[1].parse()?;
+
+        Ok(Workspace {
+            workspace_id,
+            timestamp,
+        })
+    }
+}


### PR DESCRIPTION
This pull request refactors the codebase by splitting up the large `src/state.rs` file into multiple smaller, focused modules. This modularization improves code organization, readability, and maintainability. The logic for types such as `SafeMap`, `Program`, `Workspace`, `Window`, and `FloatingWindow` has been moved into their own files under the `src/state/` directory, and these modules are now re-exported from `src/state/mod.rs`.

**Codebase modularization:**

* Split the monolithic `src/state.rs` file into several modules: `safemap.rs`, `program.rs`, `workspace.rs`, `window.rs`, and `floatingwindow.rs`, each containing the definition and implementation of a specific type. (`src/state/safemap.rs`, `src/state/program.rs`, `src/state/workspace.rs`, `src/state/window.rs`, `src/state/floatingwindow.rs`) [[1]](diffhunk://#diff-fa723a3a6290426f69a431b73391b96c12c856fa2a3df500d50c3a140a8b2c08R1-R16) [[2]](diffhunk://#diff-0a6981efe1ea3cf8d1adcf871273f6e888c701eced9f1a47e5ccff448a2705e4R1-R64) [[3]](diffhunk://#diff-c08194c924af26efcb671bcd211d6f2549f38452f4f4b9e9354850ae93a445adR1-R37) [[4]](diffhunk://#diff-5032a5223bbab633065ae0d8113c1031a0f470fe36489c6d876719dc6c8f607eR1-R8) [[5]](diffhunk://#diff-057bd3c12d4007609f7396d17b11940bb42030b31aed5fb449d73e648d45102cR1-R43)
* Updated `src/state/mod.rs` to import and publicly re-export these new modules, ensuring their types are available throughout the codebase.

**Type and trait implementation organization:**

* Moved the implementations of `Display` and `FromStr` traits for `Program`, `Workspace`, and `FloatingWindow` to their respective new module files, keeping related logic together and easier to maintain. [[1]](diffhunk://#diff-0a6981efe1ea3cf8d1adcf871273f6e888c701eced9f1a47e5ccff448a2705e4R1-R64) [[2]](diffhunk://#diff-c08194c924af26efcb671bcd211d6f2549f38452f4f4b9e9354850ae93a445adR1-R37) [[3]](diffhunk://#diff-057bd3c12d4007609f7396d17b11940bb42030b31aed5fb449d73e648d45102cR1-R43)

**Code cleanup:**

* Removed the now-redundant type and trait implementations from the original file, reducing duplication and streamlining the code.

These changes make the codebase easier to navigate and maintain, as each type and its associated logic are clearly separated into dedicated files.