### PR TITLE
Added missing config option in read me

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,11 @@ frequency = 5 # How often nest will look for new floating windows
 [floating.filter]
 mode = "Include" # Include, Exclude
 programs = [] # List of program classes you wish to either include or exclude
+
+[restore]
+timeout = 120 # If a program closes before this timeout, you'll be returned to your previous workspace.
+
+[restore.filter]
+mode = "Include" # Include, Exclude
+programs = [] # List of program classes you wish to either include or exclude
 ```


### PR DESCRIPTION
This pull request updates the configuration documentation in `README.md` to introduce a new restore feature for workspace management. The changes add options for controlling how and when users are returned to their previous workspace after a program closes.

Restore feature documentation:

* Added a `[restore]` section with a `timeout` parameter, allowing users to specify the time window (in seconds) for automatic workspace restoration when a program closes.
* Added a `[restore.filter]` section, enabling users to include or exclude specific program classes from the restore behavior, similar to the existing floating window filter.